### PR TITLE
[FEAT] Melhorias no processo de CI/CD, para executar com cache e verificar formatação

### DIFF
--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -65,4 +65,4 @@ jobs:
         run: flutter --version
 
       - name: Format code
-        run: flutter format --fix .
+        run: dart format --fix .

--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -22,7 +22,7 @@ jobs:
           channel: "stable"
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.pub-cache
@@ -65,4 +65,4 @@ jobs:
         run: flutter --version
 
       - name: Format code
-        run: dart format --fix .
+        run: dart format --set-exit-if-changed .

--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -53,7 +53,7 @@ jobs:
           channel: "stable"
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.pub-cache

--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -1,10 +1,13 @@
 name: CI
 
-on: pull_request
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
-  flutter_test:
-    name: Run Flutter Test
+  flutter_analysis:
+    name: Analyze flutter code
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -12,13 +15,54 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
-      - name: Set up Flutter
+
+      - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
+          channel: "stable"
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.pub-cache
+          key: ${{ runner.os }}-flutter-${{ hashFiles('pubspec.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-flutter-
+
       - name: Flutter Version
         run: flutter --version
+
       - name: Flutter pub get
         run: flutter pub get
+
       - name: Flutter analyze
         run: flutter analyze --no-fatal-infos
+
+  flutter_format:
+    name: Format flutter code
+    runs-on: ubuntu-latest
+    needs: flutter_analysis
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.pub-cache
+          key: ${{ runner.os }}-flutter-${{ hashFiles('pubspec.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-flutter-
+
+      - name: Flutter Version
+        run: flutter --version
+
+      - name: Format code
+        run: flutter format --fix .


### PR DESCRIPTION
Estou adicionando um job que irá falhar, caso o código não esteja corretamente formatado. Com um simples `dart fornat --fix .` é possível realizar estas mudanças, e aí só será necessário fazer um commit e dar push.

A importância da formatação do código se dá, pois quando fazemos alterações em um arquivo que não está formatado, junto do commit (e do PR) vão ir as alterações apenas de formatação. Isso atrasa o code review, porque quem estiver olhando o código, vai achar que foram feitas alterações ali, ao invés de apenas um auto-formatter da IDE de alguém