### PR TITLE
[FEAT #147] - Default warning alert message

### DIFF
--- a/design_system/lib/src/alert/alert_widget.dart
+++ b/design_system/lib/src/alert/alert_widget.dart
@@ -24,7 +24,7 @@ class AlertWidget extends StatelessWidget {
             child: Padding(
               padding: const EdgeInsets.fromLTRB(20, 17, 20, 17),
               child: SelectableText(
-                message,
+                message.isNotEmpty ? message : "Ocorreu um erro inesperado.",
                 style: TextStyle(
                   color: color,
                   fontWeight: FontWeight.w500,


### PR DESCRIPTION
Resolves #147 
- feat: Add default error message when the message string is empty

Adicionando essa mensagem padrão porque teve casos que o dio retorna um erro mas sem uma mensagem de erro, apenas uma string vazia. Dessa forma não aparecia nenhuma mensagem no `warning-alert`, apenas um quadrado vermelho sem nada