### PR TITLE
fix: Consertar o estado do CooButton quando isLoading for true

### DIFF
--- a/design_system/lib/src/buttons/coo_button/coo_button.dart
+++ b/design_system/lib/src/buttons/coo_button/coo_button.dart
@@ -165,20 +165,21 @@ class CooButton extends StatelessWidget {
                   borderRadius: BorderRadius.circular(8.0),
                 ),
               ),
-              onPressed: enable ? onPressed : null,
-              child: isLoading
-                  ? const CircularProgressIndicator(
-                      color: Colors.white,
-                    )
-                  : _ContentButton(
-                      icon: Icon(
-                        icon,
-                        color: _backgroundColor,
-                      ),
-                      label: label,
-                      textColor: _backgroundColor,
-                      colors: colors,
-                    ),
+              onPressed: () {
+                if (enable && !isLoading) {
+                  onPressed();
+                }
+              },
+              child: _ContentButton(
+                icon: Icon(
+                  icon,
+                  color: _backgroundColor,
+                ),
+                label: label,
+                textColor: _backgroundColor,
+                colors: colors,
+                isLoading: isLoading,
+              ),
             )
           : ElevatedButton(
               style: ElevatedButton.styleFrom(
@@ -188,20 +189,21 @@ class CooButton extends StatelessWidget {
                   borderRadius: BorderRadius.circular(8.0),
                 ),
               ),
-              onPressed: enable ? onPressed : null,
-              child: isLoading
-                  ? const CircularProgressIndicator(
-                      color: Colors.white,
-                    )
-                  : _ContentButton(
-                      icon: Icon(
-                        icon,
-                        color: _textColor,
-                      ),
-                      label: label,
-                      textColor: _textColor,
-                      colors: colors,
-                    ),
+              onPressed: () {
+                if (enable && !isLoading) {
+                  onPressed();
+                }
+              },
+              child: _ContentButton(
+                icon: Icon(
+                  icon,
+                  color: _textColor,
+                ),
+                label: label,
+                textColor: _textColor,
+                colors: colors,
+                isLoading: isLoading,
+              ),
             ),
     );
   }
@@ -213,28 +215,39 @@ class _ContentButton extends StatelessWidget {
     required this.label,
     required this.textColor,
     required this.colors,
+    required this.isLoading,
   });
 
   final Icon? icon;
   final String label;
   final Color? textColor;
   final CoopartilharColors colors;
+  final bool isLoading;
 
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
-        icon != null && label.isNotEmpty
-            ? const SizedBox(width: 8)
-            : Container(),
-        Text(
-          label,
-          style: textTheme.bodyMedium?.copyWith(color: textColor),
-        ),
-        Center(child: icon ?? Container()),
-      ],
-    );
+    return isLoading
+        ? const Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              CircularProgressIndicator(
+                color: Colors.white,
+              ),
+            ],
+          )
+        : Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              icon != null && label.isNotEmpty
+                  ? const SizedBox(width: 8)
+                  : Container(),
+              Text(
+                label,
+                style: textTheme.bodyMedium?.copyWith(color: textColor),
+              ),
+              Center(child: icon ?? Container()),
+            ],
+          );
   }
 }


### PR DESCRIPTION
resolves #165 

### Agora o botão não aceita mais os cliques em estado de loading

**comportamento anterior:**

![image](https://github.com/Flutterando/calamidade/assets/143228087/56c60b2d-65e2-4584-8558-ef47c807b536)


**novo comportamento:**

![Captura de tela 2024-05-18 232100](https://github.com/Flutterando/calamidade/assets/143228087/8cd6493f-256d-4e18-b0ba-20d01e1c4921)
![Captura de tela 2024-05-18 232227](https://github.com/Flutterando/calamidade/assets/143228087/138096bf-f5eb-4619-aeb5-73ac4bdc3129)
