### PR TITLE
Fix/#187-adjust-logo-resolution

### DIFF
--- a/app/lib/app/(public)/affiliated_first_action/presentation/affiliated_first_action_page.dart
+++ b/app/lib/app/(public)/affiliated_first_action/presentation/affiliated_first_action_page.dart
@@ -24,7 +24,8 @@ class _AffiliatedFirstActionPageState extends State<AffiliatedFirstActionPage> {
             mainAxisAlignment: MainAxisAlignment.spaceEvenly,
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              const Image(image: CooImages.cooBrand1),
+              const Center(
+                  child: Image(image: CooImages.cooBrand2, height: 166)),
               Column(
                 mainAxisAlignment: MainAxisAlignment.start,
                 crossAxisAlignment: CrossAxisAlignment.center,

--- a/app/lib/app/(public)/auth/check_affiliated/check_affiliated_page.dart
+++ b/app/lib/app/(public)/auth/check_affiliated/check_affiliated_page.dart
@@ -88,7 +88,8 @@ class _CheckAffiliatedPageState extends State<CheckAffiliatedPage> {
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
                   const Spacer(),
-                  const Image(image: CooImages.cooBrand1),
+                  const Center(
+                      child: Image(image: CooImages.cooBrand2, height: 166)),
                   const Spacer(),
                   Row(
                     children: [

--- a/app/lib/app/(public)/auth/login/login_page.dart
+++ b/app/lib/app/(public)/auth/login/login_page.dart
@@ -68,7 +68,8 @@ class _LoginPageState extends State<LoginPage> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 const SizedBox(height: 60),
-                const Center(child: Image(image: CooImages.cooBrand1)),
+                const Center(
+                    child: Image(image: CooImages.cooBrand2, height: 166)),
                 const SizedBox(height: 60),
                 Center(
                   child: Text(

--- a/app/lib/app/(public)/onboarding/onboarding_page.dart
+++ b/app/lib/app/(public)/onboarding/onboarding_page.dart
@@ -61,6 +61,7 @@ class _OnboardingPageState extends State<OnboardingPage> {
                           mainAxisSize: MainAxisSize.max,
                           children: [
                             const Spacer(),
+                            //TODO: Alterar para CooImages.cooBrand2, para aumentar a resolução do logo, não fiz isso pois a page precisa de credenciais para abrir corretamente
                             const Image(image: CooImages.cooBrand1),
                             const SizedBox(
                               height: 32,

--- a/app/lib/app/(public)/register_assistence/register_assistence_page.dart
+++ b/app/lib/app/(public)/register_assistence/register_assistence_page.dart
@@ -76,7 +76,7 @@ class _RegisterAssistencePageState extends State<RegisterAssistencePage> {
                         child: Padding(
                           padding: EdgeInsets.only(top: 16),
                           child: Image(
-                            image: CooImages.cooBrand1,
+                            image: CooImages.cooBrand2,
                             width: 150,
                             height: 124,
                           ),


### PR DESCRIPTION
As logos estavam com a imagem de menor resolução (CooImages.cooBrand1), apenas alterei a imagem para a próxima maior resolução (CooImages.cooBrand2), e setei uma altura fixa de 166 (que era a altura da imagem cooBrand1 anterior). Além disso, setei sempre como Center, que era o comportamento anterior. 

Adicionei um comentário na tela de onBoarding para ser feita essa atualização, pois a tela de onboarding precisa de credenciais para acessá-lo por completo e eu não tenho.