### PR TITLE
Fix: navigate to forgotPasswordPage

### DIFF
--- a/app/lib/app/(public)/auth/login/login_page.dart
+++ b/app/lib/app/(public)/auth/login/login_page.dart
@@ -114,7 +114,7 @@ class _LoginPageState extends State<LoginPage> {
                           ),
                           InkWell(
                             onTap: () {
-                              Routefly.navigate(routePaths.auth.forgotPassword);
+                              Routefly.push(routePaths.auth.forgotPassword);
                             },
                             child: Text(
                               'Esqueci minha senha',

--- a/core_module/lib/src/adapters/phone_adapter.dart
+++ b/core_module/lib/src/adapters/phone_adapter.dart
@@ -1,6 +1,7 @@
 class PhoneAdapter {
   static String applyMask(String text) {
     final phone = text.replaceAll(RegExp(r'\D'), '');
+    if (phone.isEmpty) return '';
     if (phone.length == 13) {
       return '+${phone.substring(0, 2)} (${phone.substring(2, 4)}) ${phone.substring(4, 9)}-${phone.substring(9)}';
     } else if (phone.length == 12) {


### PR DESCRIPTION
Estando na tela de login, ao clicar em "Esqueci minha senha", o app redireciona para a tela de recuperação de senha, mas não conseguia voltar para a tela de login.

Para ajustar isso foi aletrado o 'navigate' pelo 'push':
` Routefly.navigate(routePaths.auth.forgotPassword);` para ` Routefly.push(routePaths.auth.forgotPassword);`